### PR TITLE
Feature: Edit Task Screen Implementation

### DIFF
--- a/TaskManager/app/edit/[id].tsx
+++ b/TaskManager/app/edit/[id].tsx
@@ -1,0 +1,100 @@
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { View, Text, TextInput, StyleSheet, Button, Alert } from 'react-native';
+import { useTaskContext } from '../../contexts/TaskContext';
+import { useEffect, useState } from 'react';
+import type { Task } from '../../types/Task';
+import BackButton from '../../components/BackButton';
+
+/**
+ * EditTaskScreen:
+ * A screen to edit an existing task using task ID from route params.
+ * It fetches the task from context, allows user to edit it, and saves updates.
+ */
+export default function EditTaskScreen() {
+    const { id } = useLocalSearchParams();
+    const router = useRouter();
+    const { tasks, editTask } = useTaskContext();
+
+    const task = tasks.find((t) => t.id === id);
+    const [title, setTitle] = useState('');
+    const [description, setDescription] = useState('');
+
+    useEffect(() => {
+        if (task) {
+            setTitle(task.title);
+            setDescription(task.description);
+        }
+    }, [task]);
+
+    const handleSave = () => {
+        if (!title.trim()) {
+            Alert.alert('Validation', 'Title is required.');
+            return;
+        }
+
+        const updatedTask: Task = {
+            ...task!,
+            title,
+            description,
+        };
+
+        editTask(updatedTask);
+        router.push('/');
+    };
+
+    if (!task) {
+        return (
+            <View style={styles.container}>
+                <Text>Task not found.</Text>
+                <BackButton />
+            </View>
+        );
+    }
+
+    return (
+        <View style={styles.container}>
+            <Text style={styles.heading}>Edit Task</Text>
+
+            <TextInput
+                style={styles.input}
+                value={title}
+                onChangeText={setTitle}
+                placeholder="Title"
+            />
+            <TextInput
+                style={[styles.input, styles.textArea]}
+                value={description}
+                onChangeText={setDescription}
+                placeholder="Description"
+                multiline
+                numberOfLines={4}
+            />
+
+            <Button title="Save Changes" onPress={handleSave} />
+            <BackButton />
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        padding: 20,
+        flex: 1,
+        backgroundColor: '#fff',
+    },
+    heading: {
+        fontSize: 22,
+        fontWeight: 'bold',
+        marginBottom: 16,
+    },
+    input: {
+        borderWidth: 1,
+        borderColor: '#ccc',
+        borderRadius: 6,
+        padding: 10,
+        marginBottom: 16,
+    },
+    textArea: {
+        height: 100,
+    },
+});

--- a/TaskManager/components/TaskCard.tsx
+++ b/TaskManager/components/TaskCard.tsx
@@ -1,5 +1,6 @@
 import { View, Text, StyleSheet } from 'react-native';
 import { Task } from '../types/Task';
+import { Link } from 'expo-router';
 
 interface Props {
     task: Task;
@@ -19,6 +20,12 @@ export default function TaskCard({ task }: Props) {
             <Text style={styles.status}>
                 {task.status === 'completed' ? '✅ Completed' : '🕒 Pending'}
             </Text>
+            <Link
+                href={{ pathname: '/edit/[id]', params: { id: task.id } } as const}
+                asChild
+            >
+                <Text style={styles.editLink}>✏️ Edit</Text>
+            </Link>
         </View>
     );
 }
@@ -38,5 +45,10 @@ const styles = StyleSheet.create({
         marginTop: 4,
         fontStyle: 'italic',
         color: '#555',
+    },
+    editLink: {
+        color: '#007bff',
+        marginTop: 8,
+        fontWeight: '500',
     },
 });

--- a/TaskManager/contexts/TaskContext.tsx
+++ b/TaskManager/contexts/TaskContext.tsx
@@ -5,6 +5,7 @@ import { mockTasks } from '../constants/mockTasks';
 interface TaskContextType {
     tasks: Task[];
     addTask: (task: Task) => void;
+    editTask: (updatedTask: Task) => void;
     // add editTask, deleteTask, toggleStatus here if needed
 }
 
@@ -13,12 +14,20 @@ const TaskContext = createContext<TaskContextType | undefined>(undefined);
 export const TaskProvider = ({ children }: { children: ReactNode }) => {
     const [tasks, setTasks] = useState<Task[]>(mockTasks);
 
+    // Function to add a new task
     const addTask = (task: Task) => {
         setTasks((prev) => [task, ...prev]);
     };
 
+    // Function to edit an existing task
+    const editTask = (updatedTask: Task) => {
+        setTasks((prev) =>
+            prev.map((task) => (task.id === updatedTask.id ? updatedTask : task))
+        );
+    };
+
     return (
-        <TaskContext.Provider value={{ tasks, addTask }}>
+        <TaskContext.Provider value={{ tasks, addTask, editTask }}>
             {children}
         </TaskContext.Provider>
     );


### PR DESCRIPTION
This PR implements the "Edit Task" feature:

- Adds a dynamic route `/edit/[id]` for editing tasks.
- Uses `useLocalSearchParams` to extract task ID from the route.
- Pre-fills the edit form using the task context.
- Allows updating title and description of a task.
- Includes a back button for navigation.

Tested on Expo Go with mock data; works as expected.
